### PR TITLE
Make sure the program name is always relative to the specified `cwd` argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# next
+
+- Breaking change on Windows: to match the Unix behavior, `prog` is
+  interpreted as relative to the directory specified by the `cwd`
+  argument (#13)
+
 # v0.12.0
 
 - Breaking change: make environments abstract so that we can later

--- a/src/spawn.ml
+++ b/src/spawn.ml
@@ -91,6 +91,11 @@ let spawn_windows ~env ~cwd ~prog ~argv ~stdin ~stdout ~stderr ~use_vfork:_ =
   let cmdline =
     String.concat (List.map argv ~f:Filename.quote) ~sep:" "
   in
+  let prog =
+    match Filename.is_relative prog, cwd with
+    | true, Some p -> Filename.concat p prog
+    | _ -> prog
+  in
   spawn_windows ~env ~cwd ~prog ~cmdline ~stdin ~stdout ~stderr
 
 let no_null s =

--- a/src/spawn.mli
+++ b/src/spawn.mli
@@ -47,6 +47,11 @@ end
     execvp function from the C library calls [/bin/sh] in this case to
     imitate the behaviors of a shell but this function doesn't.
 
+    Note that when [prog] is a relative filename, it is interpreted as
+    a path relative to the working directory specified by the [cwd]
+    argument. On Windows, this differs from what the underlying
+    [CreateProcess] function does.
+
     {b Command line arguments}
 
     [argv] is the full command line. The first element should be the program

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
 (library
  (name spawn_test)
  (libraries unix spawn)
- (inline_tests)
+ (inline_tests (deps exe/hello.exe))
  (preprocess (pps ppx_expect)))

--- a/test/exe/dune
+++ b/test/exe/dune
@@ -1,0 +1,1 @@
+(executable (name hello))

--- a/test/exe/hello.ml
+++ b/test/exe/hello.ml
@@ -1,0 +1,1 @@
+print_endline "Hello, world!"

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -100,3 +100,7 @@ let%expect_test "inheriting stdout with close-on-exec set" =
     wait (Spawn.spawn () ~prog ~argv:[shell; arg; {|echo "hello world"|}]);
   end;
   [%expect {| hello world |}]
+
+let%expect_test "prog relative to cwd" =
+  wait (Spawn.spawn () ~prog:"./hello.exe" ~argv:["hello"] ~cwd:(Path "exe"));
+  [%expect {| Hello, world! |}]


### PR DESCRIPTION
On Windows, the underlying `CreateProcess` function take a program name that is relative to the cwd of the current working process, which is inconsistent with the behavior of `Spawn.spawn` on Unix.

The Windows behavior seems better to me, however the two behaviors cannot be unified without a breaking change and given that this library is more likely to have been used on Unix, it seems safer to do the breaking change for Windows.