### PR TITLE
Investigate OSX failure

### DIFF
--- a/src/spawn_stubs.c
+++ b/src/spawn_stubs.c
@@ -143,6 +143,7 @@ static void subprocess_failure(int failure_fd,
 {
   struct subprocess_failure failure;
   sigset_t sigset;
+  ssize_t written;
 
   CASSERT(sizeof(failure) < PIPE_BUF)
 
@@ -155,8 +156,11 @@ static void subprocess_failure(int failure_fd,
   pthread_sigmask(SIG_SETMASK, &sigset, NULL);
 
   /* Write is atomic as buffer is smaller than PIPE_BUF
-     (required by POSIX.1-2001, as claimed in [man 7 pipe]) */
-  write(failure_fd, &failure, sizeof(failure));
+     (required by POSIX.1-2001, as claimed in [man 7 pipe]).
+
+     We only store the result of [write] to avoid a warning.
+ */
+  written = write(failure_fd, &failure, sizeof(failure));
   _exit(127);
 }
 

--- a/src/spawn_stubs.c
+++ b/src/spawn_stubs.c
@@ -9,10 +9,27 @@
 
 #include <errno.h>
 
+#if defined(__APPLE__)
+
+CAMLprim value spawn_is_osx()
+{
+  return Val_true;
+}
+
+#else
+
+CAMLprim value spawn_is_osx()
+{
+  return Val_false;
+}
+
+#endif
+
 #if !defined(_WIN32)
 
 #include <assert.h>
 #include <string.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>

--- a/test/dune
+++ b/test/dune
@@ -4,6 +4,9 @@
  (enabled_if
   (>= %{ocaml_version} 4.04))
  (inline_tests
-  (deps exe/hello.exe))
+  (deps
+   exe/hello.exe
+   exe/list_files.exe
+   (sandbox always)))
  (preprocess
   (pps ppx_expect)))

--- a/test/exe/dune
+++ b/test/exe/dune
@@ -1,2 +1,2 @@
-(executable
- (name hello))
+(executables
+ (names hello list_files))

--- a/test/exe/list_files.ml
+++ b/test/exe/list_files.ml
@@ -1,0 +1,3 @@
+let () =
+  Sys.readdir "." |> Array.to_list |> List.sort String.compare
+  |> List.iter print_endline


### PR DESCRIPTION
- added a test for `cwd:(Path _)`
- made cwd tests more reproducible by printing `$TMPDIR` rather than the actual cwd, given that it prints `/private/tmp` rather than `/tmp` on OSX