### PR TITLE
Use ~cloexec on windows

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -13,7 +13,7 @@
  (name spawn)
  (depends
   (ppx_expect :with-test)
-  (ocaml (>= 4.02.3)))
+  (ocaml (>= 4.05)))
  (synopsis "Spawning sub-processes")
  (description "\
 Spawn is a small library exposing only one functionality: spawning sub-process.
@@ -27,7 +27,7 @@ working directory
 sub-process. For instance if a command is not found, you get a proper
 [Unix.Unix_error] exception
 
-3. improve performances by using vfork when available. It is often
+3. improve performance by using vfork when available. It is often
 claimed that nowadays fork is as fast as vfork, however in practice
 fork takes time proportional to the process memory while vfork is
 constant time. In application using a lot of memory, vfork can be

--- a/dune-workspace.dev
+++ b/dune-workspace.dev
@@ -1,8 +1,6 @@
 (lang dune 2.5)
 
 ;; This file is used by `make all-supported-ocaml-versions`
-(context (opam (switch 4.02.3)))
-(context (opam (switch 4.03.0)))
-(context (opam (switch 4.04.2)))
 (context (opam (switch 4.05.0)))
 ;(context (opam (switch 4.06.0)))
+(context (opam (switch 4.11.1)))

--- a/spawn.opam
+++ b/spawn.opam
@@ -13,7 +13,7 @@ working directory
 sub-process. For instance if a command is not found, you get a proper
 [Unix.Unix_error] exception
 
-3. improve performances by using vfork when available. It is often
+3. improve performance by using vfork when available. It is often
 claimed that nowadays fork is as fast as vfork, however in practice
 fork takes time proportional to the process memory while vfork is
 constant time. In application using a lot of memory, vfork can be
@@ -28,7 +28,7 @@ bug-reports: "https://github.com/janestreet/spawn/issues"
 depends: [
   "dune" {>= "2.8"}
   "ppx_expect" {with-test}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.05"}
   "odoc" {with-doc}
 ]
 build: [

--- a/src/spawn.ml
+++ b/src/spawn.ml
@@ -144,20 +144,8 @@ let spawn ?env ?(cwd = Working_dir.Inherit) ~prog ~argv ?(stdin = Unix.stdin)
 external safe_pipe : unit -> Unix.file_descr * Unix.file_descr = "spawn_pipe"
 
 let safe_pipe =
-  if Sys.win32 then (
+  if Sys.win32 then
     fun () ->
-  (* CR-someday jdimino: fix race conditions on Windows *)
-  let fdr, fdw = Unix.pipe () in
-  match
-    Unix.set_close_on_exec fdr;
-    Unix.set_close_on_exec fdw
-  with
-  | () -> (fdr, fdw)
-  | exception exn ->
-    (try Unix.close fdr with
-    | _ -> ());
-    (try Unix.close fdw with
-    | _ -> ());
-    raise exn
-  ) else
+  Unix.pipe ~cloexec:true ()
+  else
     safe_pipe


### PR DESCRIPTION
It seems to be supported on windows now.

Is safe_pipe still needed? OCaml's `Unix.pipe` is using `pipe2` it's available