### PR TITLE
use GetProcessId for pid in spawn_windows

### DIFF
--- a/src/spawn_stubs.c
+++ b/src/spawn_stubs.c
@@ -563,6 +563,7 @@ CAMLprim value spawn_windows(value v_env,
 {
   STARTUPINFO si;
   PROCESS_INFORMATION pi;
+  DWORD pid;
 
   ZeroMemory(&si, sizeof(si));
   ZeroMemory(&pi, sizeof(pi));
@@ -592,10 +593,13 @@ CAMLprim value spawn_windows(value v_env,
     uerror("CreateProcess", Nothing);
   }
 
+  pid = GetProcessId(pi.hProcess);
+
   close_std_handles(&si);
+  CloseHandle(pi.hProcess);
   CloseHandle(pi.hThread);
 
-  return Val_long(pi.hProcess);
+  return Val_long(pid);
 }
 
 CAMLprim value spawn_pipe()


### PR DESCRIPTION
The `spawn_windows` C stub currently returns `pi.hProcess`, which is a `HANDLE` and not equivalent to the actual process id.

This PR uses `GetProcessID` to get the process ID from the handle: https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getprocessid

Additionally, the `hProcess` handle is closed as specified here: https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-process_information#remarks