### PR TITLE
Search $PATH for sleep binary in test

### DIFF
--- a/test/tests.ml
+++ b/test/tests.ml
@@ -147,7 +147,7 @@ let%expect_test "pgid tests" =
 let%test_unit "sigprocmask" =
   if not (Sys.win32) then (
     let run ?sigprocmask expected_signal =
-      let pid = Spawn.spawn ?sigprocmask ~prog:"/usr/bin/sleep" ~argv:[ "60" ] () in
+      let pid = Spawn.spawn ?sigprocmask ~prog:"/usr/bin/sleep" ~argv:[ "sleep"; "60" ] () in
       Unix.kill pid Sys.sigusr1;
       Unix.kill pid Sys.sigkill;
       match Unix.waitpid [] pid with

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -147,7 +147,8 @@ let%expect_test "pgid tests" =
 let%test_unit "sigprocmask" =
   if not (Sys.win32) then (
     let run ?sigprocmask expected_signal =
-      let pid = Spawn.spawn ?sigprocmask ~prog:"/usr/bin/sleep" ~argv:[ "sleep"; "60" ] () in
+      let prog = Program_lookup.find_prog "sleep" in
+      let pid = Spawn.spawn ?sigprocmask ~prog ~argv:[ "sleep"; "60" ] () in
       Unix.kill pid Sys.sigusr1;
       Unix.kill pid Sys.sigkill;
       match Unix.waitpid [] pid with


### PR DESCRIPTION
We had the location of sleep(1) hard-coded as `/usr/bin/sleep` in a test, but on MacOS it’s in `/bin`, not in `/usr/bin`. This PR searches the $PATH for `sleep` and uses the result.