### PR TITLE
On macOS >= 12, don't use vfork(2)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,7 +18,7 @@ jobs:
         # We test:
         # - once for each architecture with the latest OCaml
         # - once for a few older versions of OCaml under Linux
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-11, macos-12, ubuntu-latest, windows-latest]
         ocaml: [4.14.0]
         include:
           - {os: ubuntu-latest, ocaml: 4.13.1}

--- a/src/spawn_stubs.c
+++ b/src/spawn_stubs.c
@@ -51,11 +51,11 @@ CAMLprim value spawn_is_osx()
 #if defined(__APPLE__)
 
 /* vfork(2) is deprecated on macOS >= 12, so we use fork(2) instead. */
-#if defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
-# if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000
-#  define vfork fork
+# if defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+#  if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000
+#   define vfork fork
+#  endif
 # endif
-#endif
 
 static int safe_pipe(int fd[2])
 {

--- a/src/spawn_stubs.c
+++ b/src/spawn_stubs.c
@@ -50,6 +50,13 @@ CAMLprim value spawn_is_osx()
 
 #if defined(__APPLE__)
 
+/* vfork(2) is deprecated on macOS >= 12, so we use fork(2) instead. */
+#if defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+# if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000
+#  define vfork fork
+# endif
+#endif
+
 static int safe_pipe(int fd[2])
 {
   int i;


### PR DESCRIPTION
**vfork**(2) is deprecated on macOS >= 12, so we need to use **fork**(2) instead to avoid deprecation warnings. (Should we use **posix_spawn**(2) where available?)