### PR TITLE
Pass ~sep label to String.concat.

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -2,7 +2,7 @@ open StdLabels
 
 let run cmd args =
   (* broken when arguments contain spaces but it's good enough for now. *)
-  let cmd = String.concat " " (cmd :: args) in
+  let cmd = String.concat ~sep:" " (cmd :: args) in
   match Sys.command cmd with
   | 0 -> ()
   | n ->


### PR DESCRIPTION
This gets rid of a warning during CI.