### PR TITLE
Clean up CI

### DIFF
--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -43,5 +43,5 @@ let () =
   | [| _; "test" |] -> test ()
   | [| _; "fmt" |] -> fmt ()
   | _ ->
-    prerr_endline "Usage: ci.ml [pin | test]";
+    prerr_endline "Usage: ci.ml [fmt | pin | test]";
     exit 1

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -11,18 +11,6 @@ let run cmd args =
 
 let opam args = run "opam" args
 
-let pin () =
-  let packages =
-    let packages = Sys.readdir "." |> Array.to_list in
-    List.fold_left packages ~init:[] ~f:(fun acc fname ->
-        if Filename.check_suffix fname ".opam" then
-          Filename.chop_suffix fname ".opam" :: acc
-        else
-          acc)
-  in
-  List.iter packages ~f:(fun package ->
-      opam [ "pin"; "add"; package ^ ".next"; "."; "--no-action" ])
-
 let test () =
   opam [ "install"; "."; "--deps-only"; "--with-test" ];
   run "dune" [ "runtest" ]
@@ -39,9 +27,8 @@ let fmt () =
 
 let () =
   match Sys.argv with
-  | [| _; "pin" |] -> pin ()
   | [| _; "test" |] -> test ()
   | [| _; "fmt" |] -> fmt ()
   | _ ->
-    prerr_endline "Usage: ci.ml [fmt | pin | test]";
+    prerr_endline "Usage: ci.ml [fmt | test]";
     exit 1

--- a/.github/workflows/ci.ml
+++ b/.github/workflows/ci.ml
@@ -11,8 +11,10 @@ let run cmd args =
 
 let opam args = run "opam" args
 
+let build () =
+  opam [ "install"; "."; "--deps-only"; "--with-test" ]
+
 let test () =
-  opam [ "install"; "."; "--deps-only"; "--with-test" ];
   run "dune" [ "runtest" ]
 
 let fmt () =
@@ -27,8 +29,9 @@ let fmt () =
 
 let () =
   match Sys.argv with
+  | [| _; "build" |] -> build ()
   | [| _; "test" |] -> test ()
   | [| _; "fmt" |] -> fmt ()
   | _ ->
-    prerr_endline "Usage: ci.ml [fmt | test]";
+    prerr_endline "Usage: ci.ml [ build | test | fmt ]";
     exit 1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,11 +1,11 @@
-name: CI
+name: Main workflow
 
 on:
   - push
   - pull_request
 
 jobs:
-  build:
+  CI:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,13 +15,13 @@ jobs:
         # - once for each architecture with the latest OCaml
         # - once for a few older versions of OCaml under Linux
         # - both macos-latest (11) and 12
+        ocaml-compiler:
+          - 4.13.1
         os:
           - macos-11
           - macos-12
           - ubuntu-latest
           - windows-latest
-        ocaml-compiler:
-          - 4.13.1
         include:
           - ocaml-compiler: 4.10.0
             os: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,8 +12,10 @@ jobs:
         # We test:
         # - once for each architecture with the latest OCaml
         # - once for a few older versions of OCaml under Linux
+        # - both macos-latest (11) and 12
         os:
-          - macos-latest
+          - macos-11
+          - macos-12
           - ubuntu-latest
           - windows-latest
         ocaml-version:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,7 +7,7 @@ on:
     - cron: 0 1 * * MON
 
 jobs:
-  CI:
+  Tests:
     strategy:
       fail-fast: false
       matrix:
@@ -20,21 +20,17 @@ jobs:
           - macos-12
           - ubuntu-latest
           - windows-latest
-        ocaml-version:
+        ocaml-compiler:
           - 4.13.1
         include:
-          - ocaml-version: 4.10.0
+          - ocaml-compiler: 4.10.0
             os: ubuntu-latest
-          - ocaml-version: 4.09.1
+          - ocaml-compiler: 4.09.1
             os: ubuntu-latest
-          - ocaml-version: 4.08.1
+          - ocaml-compiler: 4.08.1
             os: ubuntu-latest
-          - ocaml-version: 4.05.0
+          - ocaml-compiler: 4.05.0
             os: ubuntu-latest
-
-    env:
-      OCAML_VERSION: ${{ matrix.ocaml-version }}
-      OS: ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
 
@@ -42,12 +38,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup OCaml ${{ matrix.ocaml-version }}
+      - name: Setup OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
-          cache-prefix: v1-${{ matrix.os }}-${{ matrix.ocaml-version }}
+          cache-prefix: v1-${{ matrix.os }}-${{ matrix.ocaml-compiler }}
           dune-cache: true
-          ocaml-compiler: ${{ matrix.ocaml-version }}
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
       - name: Build dependencies
         run: opam exec -- ocaml .github/workflows/ci.ml build
@@ -55,6 +51,25 @@ jobs:
       - name: Run test suite
         run: opam exec -- ocaml .github/workflows/ci.ml test
 
+  Format:
+    strategy:
+      matrix:
+        include:
+         - ocaml-compiler: 4.13.1
+           os: ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          cache-prefix: v1-${{ matrix.os }}-${{ matrix.ocaml-compiler }}
+          dune-cache: true
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
       - name: Check that source is well formatted
-        run: opam exec -- ocaml .github/workflows/ci.ml fmt
-        if: env.OCAML_VERSION == '4.13.1' && env.OS == 'ubuntu-latest'
+        uses: ocaml/setup-ocaml/lint-fmt@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,8 +1,10 @@
 name: Main workflow
 
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+  schedule:
+    - cron: 0 1 * * MON
 
 jobs:
   CI:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,14 +43,9 @@ jobs:
       - name: Setup OCaml ${{ matrix.ocaml-version }}
         uses: ocaml/setup-ocaml@v2
         with:
-          cache-prefix:  v1-${{ matrix.os }}
-          dune-cache:    true
+          cache-prefix: v1-${{ matrix.os }}
+          dune-cache: true
           ocaml-compiler: ${{ matrix.ocaml-version }}
-          opam-pin:      true
-          opam-local-packages: "*.opam"
-
-      # - name: Pin OPAM versions
-      #   run: opam exec -- ocaml .github/workflows/ci.ml pin
 
       - name: Run test suite
         run: opam exec -- ocaml .github/workflows/ci.ml test

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,6 +47,9 @@ jobs:
           dune-cache: true
           ocaml-compiler: ${{ matrix.ocaml-version }}
 
+      - name: Build dependencies
+        run: opam exec -- ocaml .github/workflows/ci.ml build
+
       - name: Run test suite
         run: opam exec -- ocaml .github/workflows/ci.ml test
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup OCaml ${{ matrix.ocaml-version }}
         uses: avsm/setup-ocaml@v1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -40,16 +40,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Use OCaml ${{ matrix.ocaml-version }}
+      - name: Setup OCaml ${{ matrix.ocaml-version }}
         uses: avsm/setup-ocaml@v1
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
 
-      - run: opam exec -- ocaml .github/workflows/ci.ml pin
+      - name: Pin OPAM versions
+        run: opam exec -- ocaml .github/workflows/ci.ml pin
 
-      - name: run test suite
+      - name: Run test suite
         run: opam exec -- ocaml .github/workflows/ci.ml test
 
-      - name: test source is well formatted
+      - name: Check that source is well formatted
         run: opam exec -- ocaml .github/workflows/ci.ml fmt
         if: env.OCAML_VERSION == '4.11.2' && env.OS == 'ubuntu-latest'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           cache-prefix:  v1-${{ matrix.os }}
           dune-cache:    true
-          ocaml-version: ${{ matrix.ocaml-version }}
+          ocaml-compiler: ${{ matrix.ocaml-version }}
           opam-pin:      true
           opam-local-packages: "*.opam"
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -57,4 +57,4 @@ jobs:
 
       - name: Check that source is well formatted
         run: opam exec -- ocaml .github/workflows/ci.ml fmt
-        if: env.OCAML_VERSION == '4.11.2' && env.OS == 'ubuntu-latest'
+        if: env.OCAML_VERSION == '4.13.1' && env.OS == 'ubuntu-latest'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup OCaml ${{ matrix.ocaml-version }}
         uses: ocaml/setup-ocaml@v2
         with:
-          cache-prefix: v1-${{ matrix.os }}
+          cache-prefix: v1-${{ matrix.os }}-${{ matrix.ocaml-version }}
           dune-cache: true
           ocaml-compiler: ${{ matrix.ocaml-version }}
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,12 +43,14 @@ jobs:
       - name: Setup OCaml ${{ matrix.ocaml-version }}
         uses: ocaml/setup-ocaml@v2
         with:
+          cache-prefix:  v1-${{ matrix.os }}
+          dune-cache:    true
           ocaml-version: ${{ matrix.ocaml-version }}
-          dune-cache: true
-          cache-prefix: v1-${{ matrix.os }}
+          opam-pin:      true
+          opam-local-packages: "*.opam"
 
-      - name: Pin OPAM versions
-        run: opam exec -- ocaml .github/workflows/ci.ml pin
+      # - name: Pin OPAM versions
+      #   run: opam exec -- ocaml .github/workflows/ci.ml pin
 
       - name: Run test suite
         run: opam exec -- ocaml .github/workflows/ci.ml test

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -44,6 +44,8 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
+          dune-cache: true
+          cache-prefix: v1-${{ matrix.os }}
 
       - name: Pin OPAM versions
         run: opam exec -- ocaml .github/workflows/ci.ml pin

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
+        uses: ocaml/setup-ocaml@v2
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
 

--- a/src/spawn.ml
+++ b/src/spawn.ml
@@ -166,7 +166,8 @@ let spawn ?env ?(cwd = Working_dir.Inherit) ~prog ~argv ?(stdin = Unix.stdin)
     | Vfork -> true
     | Fork -> false
   in
-  backend ~env ~cwd ~prog ~argv ~stdin ~stdout ~stderr ~use_vfork ~setpgid ~sigprocmask
+  backend ~env ~cwd ~prog ~argv ~stdin ~stdout ~stderr ~use_vfork ~setpgid
+    ~sigprocmask
 
 external safe_pipe : unit -> Unix.file_descr * Unix.file_descr = "spawn_pipe"
 

--- a/src/spawn.mli
+++ b/src/spawn.mli
@@ -96,14 +96,14 @@ end
 
     {b Signals}
 
-    On Unix, by default, the sub-process will have all its signals unblocked.
-    If [sigprocmask] is passed, the sub-process will have its sigprocmask modified
-    with the given [sigprocmask_command], relative to the calling thread.
-    At no point will any OCaml function observe any intermediate signal mask.
+    On Unix, by default, the sub-process will have all its signals unblocked. If
+    [sigprocmask] is passed, the sub-process will have its sigprocmask modified
+    with the given [sigprocmask_command], relative to the calling thread. At no
+    point will any OCaml function observe any intermediate signal mask.
 
     Attempts to unblock a signal that is not blocked, to block a signal that is
-    already blocked, or to block a signal that cannot be blocked (e.g., SIGSTOP, SIGKILL)
-    are allowed and will be silently ignored.
+    already blocked, or to block a signal that cannot be blocked (e.g., SIGSTOP,
+    SIGKILL) are allowed and will be silently ignored.
 
     {b Implementation}
 
@@ -120,7 +120,8 @@ val spawn :
   -> ?stderr:Unix.file_descr
   -> ?unix_backend:Unix_backend.t (* default: [Unix_backend.default] *)
   -> ?setpgid:Pgid.t
-  -> ?sigprocmask:(Unix.sigprocmask_command * int list) (** default: unblock all signals in child *)
+  -> ?sigprocmask:Unix.sigprocmask_command * int list
+       (** default: unblock all signals in child *)
   -> unit
   -> int
 

--- a/test/exe/hello.ml
+++ b/test/exe/hello.ml
@@ -1,2 +1,1 @@
-let () =
-  print_endline "Hello, world!"
+let () = print_endline "Hello, world!"

--- a/test/exe/print_env.ml
+++ b/test/exe/print_env.ml
@@ -1,3 +1,4 @@
-let () = match Sys.getenv "FOO" with
+let () =
+  match Sys.getenv "FOO" with
   | exception _ -> print_endline "None"
   | str -> Printf.printf "Some %S\n" str

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -140,11 +140,14 @@ let%expect_test "prog relative to cwd" =
 
 let%expect_test "env" =
   let tst v =
-    let env = match v with
+    let env =
+      match v with
       | None -> Spawn.Env.of_list []
-      | Some v -> Spawn.Env.of_list ["FOO=" ^ v]
+      | Some v -> Spawn.Env.of_list [ "FOO=" ^ v ]
     in
-    wait (Spawn.spawn () ~env ~prog:"./print_env.exe" ~argv:["print_env"] ~cwd:(Path "exe"))
+    wait
+      (Spawn.spawn () ~env ~prog:"./print_env.exe" ~argv:[ "print_env" ]
+         ~cwd:(Path "exe"))
   in
   tst (Some "foo");
   [%expect {| Some "foo" |}];
@@ -160,22 +163,22 @@ let%expect_test "pgid tests" =
   [%expect {||}]
 
 let%test_unit "sigprocmask" =
-  if not (Sys.win32) then (
+  if not Sys.win32 then (
     let run ?sigprocmask expected_signal =
       let prog = Program_lookup.find_prog "sleep" in
       let pid = Spawn.spawn ?sigprocmask ~prog ~argv:[ "sleep"; "60" ] () in
       Unix.kill pid Sys.sigusr1;
       Unix.kill pid Sys.sigkill;
       match Unix.waitpid [] pid with
-      | _, WSIGNALED signal -> assert(signal = expected_signal)
+      | _, WSIGNALED signal -> assert (signal = expected_signal)
       | _ -> failwith "unexpected"
     in
     run Sys.sigusr1;
-    run ~sigprocmask:(SIG_BLOCK, [Sys.sigusr1]) Sys.sigkill;
+    run ~sigprocmask:(SIG_BLOCK, [ Sys.sigusr1 ]) Sys.sigkill
   )
 
 (* This should be at the end to clean up the test environment *)
 let () =
   Unix.unlink "sub/foo";
   Unix.unlink "sub/bar";
-  Unix.rmdir "sub";
+  Unix.rmdir "sub"


### PR DESCRIPTION
This PR cleans up the GitHub Actions CI setup:

  - Upgrades actions such as `actions/checkout` to v3 from v2, and `ocaml/setup-ocaml` to v2 from v1.
  - Enables caching of artifacts from one run to the next.
  - Runs CI weekly even if there are no events, in order to keep the caches warm.
  - Removes the pinning step from the CI workflow because `ocaml/setup-ocaml@v2` does that automatically.
  - Refactors the single CI job into two (tests and format check), and names/rationalizes the steps.
  - Restores the format check, which wasn't happening; fixes the formatting so the check passes.
  - Uses `ocaml/setup-ocaml/fmt-lint` to check code formatting, rather than bespoke code.