### PR TITLE
Fallback on _POSIX_PIPE_BUF w/ missing PIPE_BUF

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Fix compatibility with systems that do not define `PIPE_BUF`. Use
+  `_POSIX_PIPE_BUF` as a fallback. (#49)
+
 - [haiku] Fix compilation on Haiku OS. The header sys/syscalls.h isn't
   available, neither is pipe2()
 

--- a/src/spawn_stubs.c
+++ b/src/spawn_stubs.c
@@ -175,7 +175,11 @@ static void subprocess_failure(int failure_fd,
   sigset_t sigset;
   ssize_t written;
 
+#ifdef PIPE_BUF
   CASSERT(sizeof(failure) < PIPE_BUF)
+#else
+  CASSERT(sizeof(failure) < _POSIX_PIPE_BUF)
+#endif
 
   set_error(&failure, errno, function, error_arg);
 


### PR DESCRIPTION
`PIPE_BUF` is optional in POSIX, e.g. "where the corresponding value is equal to or greater than the stated minimum, but where the value can vary depending on the file to which it is applied." [1]

GNU/Hurd does not provide `PIPE_BUF`, so fallback to its minimum acceptable value, that is `_POSIX_PIPE_BUF`.

[1] https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html