### PR TITLE
Skip pthread_setcancelstate on android

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Skip calls to pthread_cancelstate on android, as its not available (#52)
+
 - Fix compatibility with systems that do not define `PIPE_BUF`. Use
   `_POSIX_PIPE_BUF` as a fallback. (#49)
 

--- a/src/spawn_stubs.c
+++ b/src/spawn_stubs.c
@@ -453,8 +453,15 @@ CAMLprim value spawn_unix(value v_env,
 
      For instance:
      http://git.musl-libc.org/cgit/musl/tree/src/process/posix_spawn.c
+
+     On android, pthread_cancel is not implemented, it is typically
+     patched out or in certain cases reimplemented with atomic_flags
+     https://github.com/search?q=org%3Atermux+pthread_setcancelstate+language%3ADiff&type=code&l=Diff
   */
+
+  #if !defined(__ANDROID__)
   pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cancel_state);
+  #endif
   sigfillset(&sigset);
   pthread_sigmask(SIG_SETMASK, &sigset, &saved_procmask);
 
@@ -542,7 +549,9 @@ CAMLprim value spawn_unix(value v_env,
 
   close(result_pipe[0]);
   pthread_sigmask(SIG_SETMASK, &saved_procmask, NULL);
+  #if !defined(__ANDROID__)
   pthread_setcancelstate(cancel_state, NULL);
+  #endif
 
   caml_leave_blocking_section();
 


### PR DESCRIPTION
This is a follow up from: https://github.com/ocaml/dune/issues/8676

Android doesn't support cancelling threads, so theres no reason to set the cancel state

For more info: https://android.googlesource.com/platform/bionic.git/+/HEAD/docs/status.md

> Thread cancellation (pthread_cancel). Unlikely to ever be implemented because of the difficulty and cost of implementing it, and the difficulty of using it correctly. See This is why we can't have safe cancellation points for more about thread cancellation.
