### PR TITLE
fix: dune bootstrap

### DIFF
--- a/src/spawn_stubs.c
+++ b/src/spawn_stubs.c
@@ -8,10 +8,8 @@
 
 #include <errno.h>
 
-#define CAML_INTERNALS
-/* for [caml_convert_signal_number] */
 #include <caml/signals.h>
-#undef CAML_INTERNALS
+CAMLextern int caml_convert_signal_number(int);
 
 #if defined(__APPLE__)
 


### PR DESCRIPTION
For some reason, dune's bootstrap process doesn't like
enabling CAML_INTERNALS. See the error in CI:

```
cd _boot && /Users/runner/work/dune/dune/_opam/bin/ocamlopt.opt -c -g -I +unix -I +threads spawn_stubs.c
vendor/spawn/src/spawn_stubs.c:481:20: error: implicit declaration of function 'caml_convert_signal_number' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
      int signal = caml_convert_signal_number(Long_val(Field(v_signals_list, 0)));
                   ^
1 error generated.
```

I'm not sure why, but it's easy enough to workaround it be declaring the
function that we need.

It's also a little cleaner this way as we only make the one private
function we need available rather than everything.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: cfe43bbb-bb8a-4289-a102-594ae6f6945d -->