### PR TITLE
Make C stubs more resistant to header structure

### DIFF
--- a/src/spawn_stubs.c
+++ b/src/spawn_stubs.c
@@ -2,6 +2,8 @@
 
 #define CAML_INTERNALS
 /* for [caml_convert_signal_number] */
+#include <caml/signals.h>
+#undef CAML_INTERNALS
 
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
@@ -10,8 +12,6 @@
 #include <caml/fail.h>
 
 #include <errno.h>
-
-#include <caml/signals.h>
 
 #if defined(__APPLE__)
 

--- a/src/spawn_stubs.c
+++ b/src/spawn_stubs.c
@@ -1,5 +1,8 @@
 #define _GNU_SOURCE
 
+#define CAML_INTERNALS
+/* for [caml_convert_signal_number] */
+
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
@@ -8,10 +11,7 @@
 
 #include <errno.h>
 
-#define CAML_INTERNALS
-/* for [caml_convert_signal_number] */
 #include <caml/signals.h>
-#undef CAML_INTERNALS
 
 #if defined(__APPLE__)
 


### PR DESCRIPTION
The existing stubs cause a warning on OCaml 5.1 because the declaration of `caml_convert_signal_number` can not be found.

The reason for that is that `<caml/signals.h>` is already included by some headers at the beginning of the file, so `CAML_SIGNALS_H` is already set by the time `<caml/signals.h>` is included manually and the extra internal definition are not included.

This used to work in previous versions of OCaml because presumably the header structure was different and `<caml/signal.h>` was not included transitively.

This fix just sets `CAML_INTERNALS` at the file level; it is not really possible to be granular in setting it.
