### PR TITLE
Convert Windows stubs to Unicode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Fix spawning processes on Windows when environment contains non-ascii
+  characters (#58)
+
 - Skip calls to pthread_cancelstate on android, as its not available (#52)
 
 - Fix compatibility with systems that do not define `PIPE_BUF`. Use

--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,8 @@
  (public_name spawn)
  (foreign_stubs
   (language c)
-  (names spawn_stubs))
+  (names spawn_stubs)
+  (flags :standard -DUNICODE -D_UNICODE))
  ;; We don't use the thread library directly, however we use pthread
  ;; functions in the stubs, so declare a dependency on thread.
  ;;

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,6 @@
 (library
  (name spawn)
  (public_name spawn)
- (modules :standard \ flags)
  (foreign_stubs
   (language c)
   (names spawn_stubs)
@@ -15,9 +14,13 @@
  (libraries unix threads))
 
 (rule
-  (with-stdout-to flags.sexp
-    (run ocaml %{dep:flags.ml})))
+  (target flags.sexp)
+  (enabled_if (= %{os_type} "Win32"))
+  (action
+    (with-stdout-to %{target} (echo "(-DUNICODE -D_UNICODE)"))))
 
 (rule
-  (with-stdout-to flags.ml
-    (echo "print_endline @@ if Sys.win32 then \"(-DUNICODE -D_UNICODE)\" else \"()\"")))
+  (target flags.sexp)
+  (enabled_if (<> %{os_type} "Win32"))
+  (action
+    (with-stdout-to %{target} (echo "()"))))

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,7 @@
 (library
  (name spawn)
  (public_name spawn)
+ (modules :standard \ flags)
  (foreign_stubs
   (language c)
   (names spawn_stubs)

--- a/src/dune
+++ b/src/dune
@@ -4,7 +4,9 @@
  (foreign_stubs
   (language c)
   (names spawn_stubs)
-  (flags (:standard (:include flags.sexp))))
+  (flags
+   (:standard
+    (:include flags.sexp))))
  ;; We don't use the thread library directly, however we use pthread
  ;; functions in the stubs, so declare a dependency on thread.
  ;;
@@ -14,13 +16,19 @@
  (libraries unix threads))
 
 (rule
-  (target flags.sexp)
-  (enabled_if (= %{os_type} "Win32"))
-  (action
-    (with-stdout-to %{target} (echo "(-DUNICODE -D_UNICODE)"))))
+ (target flags.sexp)
+ (enabled_if
+  (= %{os_type} "Win32"))
+ (action
+  (with-stdout-to
+   %{target}
+   (echo "(-DUNICODE -D_UNICODE)"))))
 
 (rule
-  (target flags.sexp)
-  (enabled_if (<> %{os_type} "Win32"))
-  (action
-    (with-stdout-to %{target} (echo "()"))))
+ (target flags.sexp)
+ (enabled_if
+  (<> %{os_type} "Win32"))
+ (action
+  (with-stdout-to
+   %{target}
+   (echo "()"))))

--- a/src/dune
+++ b/src/dune
@@ -4,7 +4,7 @@
  (foreign_stubs
   (language c)
   (names spawn_stubs)
-  (flags :standard -DUNICODE -D_UNICODE))
+  (flags (:standard (:include flags.sexp))))
  ;; We don't use the thread library directly, however we use pthread
  ;; functions in the stubs, so declare a dependency on thread.
  ;;
@@ -12,3 +12,11 @@
  ;; c_library_flags. However, this would require testing that it is
  ;; supported.
  (libraries unix threads))
+
+(rule
+  (with-stdout-to flags.sexp
+    (run ocaml %{dep:flags.ml})))
+
+(rule
+  (with-stdout-to flags.ml
+    (echo "print_endline @@ if Sys.win32 then \"(-DUNICODE -D_UNICODE)\" else \"()\"")))

--- a/src/spawn.ml
+++ b/src/spawn.ml
@@ -42,13 +42,16 @@ module Env_win32 : Env = struct
   type t = string
 
   let of_list env =
-    let len = List.fold_left env ~init:1 ~f:(fun acc s -> acc + String.length s + 1) in
-    let buf = Buffer.create len in
-    List.iter env ~f:(fun s ->
-      Buffer.add_string buf s;
-      Buffer.add_char buf '\000');
-    Buffer.add_char buf '\000';
-    Buffer.contents buf
+    if env = [] then
+      "\000\000"
+    else
+      let len = List.fold_left env ~init:1 ~f:(fun acc s -> acc + String.length s + 1) in
+      let buf = Buffer.create len in
+      List.iter env ~f:(fun s ->
+        Buffer.add_string buf s;
+        Buffer.add_char buf '\000');
+      Buffer.add_char buf '\000';
+      Buffer.contents buf
   ;;
 end
 

--- a/src/spawn.ml
+++ b/src/spawn.ml
@@ -32,6 +32,16 @@ module Unix_backend = struct
   ;;
 end
 
+let no_null s =
+  if String.contains s '\000'
+  then
+    Printf.ksprintf
+      invalid_arg
+      "Spawn.Env.of_list: NUL bytes are not allowed in the environment but found one \
+       in %S"
+      s
+;;
+
 module type Env = sig
   type t
 
@@ -48,6 +58,7 @@ module Env_win32 : Env = struct
       let len = List.fold_left env ~init:1 ~f:(fun acc s -> acc + String.length s + 1) in
       let buf = Buffer.create len in
       List.iter env ~f:(fun s ->
+        no_null s;
         Buffer.add_string buf s;
         Buffer.add_char buf '\000');
       Buffer.add_char buf '\000';
@@ -57,16 +68,6 @@ end
 
 module Env_unix : Env = struct
   type t = string list
-
-  let no_null s =
-    if String.contains s '\000'
-    then
-      Printf.ksprintf
-        invalid_arg
-        "Spawn.Env.of_list: NUL bytes are not allowed in the environment but found one \
-         in %S"
-        s
-  ;;
 
   let of_list l =
     List.iter l ~f:no_null;

--- a/src/spawn.ml
+++ b/src/spawn.ml
@@ -37,8 +37,8 @@ let no_null s =
   then
     Printf.ksprintf
       invalid_arg
-      "Spawn.Env.of_list: NUL bytes are not allowed in the environment but found one \
-       in %S"
+      "Spawn.Env.of_list: NUL bytes are not allowed in the environment but found one in \
+       %S"
       s
 ;;
 
@@ -52,9 +52,9 @@ module Env_win32 : Env = struct
   type t = string
 
   let of_list env =
-    if env = [] then
-      "\000\000"
-    else
+    if env = []
+    then "\000\000"
+    else (
       let len = List.fold_left env ~init:1 ~f:(fun acc s -> acc + String.length s + 1) in
       let buf = Buffer.create len in
       List.iter env ~f:(fun s ->
@@ -62,7 +62,7 @@ module Env_win32 : Env = struct
         Buffer.add_string buf s;
         Buffer.add_char buf '\000');
       Buffer.add_char buf '\000';
-      Buffer.contents buf
+      Buffer.contents buf)
   ;;
 end
 

--- a/src/spawn_stubs.c
+++ b/src/spawn_stubs.c
@@ -1,5 +1,25 @@
 #define _GNU_SOURCE
 
+/* Must come before any other caml/ headers are included */
+#define CAML_INTERNALS
+
+#ifdef _WIN32
+/* for [caml_win32_multi_byte_to_wide_char] */
+#include <caml/osdeps.h>
+
+/* Prior to OCaml 5.0, the function was called win_multi_byte_to_wide_char */
+#include <caml/version.h>
+#if OCAML_VERSION_MAJOR < 5
+#define caml_win32_multi_byte_to_wide_char win_multi_byte_to_wide_char
+#define caml_win32_maperr win32_maperr
+#endif
+#endif
+
+/* for [caml_convert_signal_number] */
+#include <caml/signals.h>
+
+#undef CAML_INTERNALS
+
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
@@ -7,11 +27,6 @@
 #include <caml/fail.h>
 
 #include <errno.h>
-
-#define CAML_INTERNALS
-/* for [caml_convert_signal_number] */
-#include <caml/signals.h>
-#undef CAML_INTERNALS
 
 #if defined(__APPLE__)
 
@@ -639,6 +654,22 @@ CAMLprim value spawn_windows(value v_env,
 {
   STARTUPINFO si;
   PROCESS_INFORMATION pi;
+  WCHAR *prog = caml_stat_strdup_to_utf16(String_val(v_prog));
+  WCHAR *cmdline = caml_stat_strdup_to_utf16(String_val(v_cmdline));
+  WCHAR *env = NULL;
+  WCHAR *cwd = NULL;
+  BOOL result;
+
+  if (Is_block(v_env)) {
+    v_env = Field(v_env, 0);
+    mlsize_t len = caml_string_length(v_env);
+    int size = caml_win32_multi_byte_to_wide_char(String_val(v_env), len, NULL, 0);
+    env = caml_stat_alloc((size + 1) * sizeof(WCHAR));
+    caml_win32_multi_byte_to_wide_char(String_val(v_env), len, env, size);
+  }
+
+  if (Is_block(v_cwd))
+    cwd = caml_stat_strdup_to_utf16(String_val(Field(v_cwd, 0)));
 
   ZeroMemory(&si, sizeof(si));
   ZeroMemory(&pi, sizeof(pi));
@@ -648,22 +679,22 @@ CAMLprim value spawn_windows(value v_env,
   if (!dup2_and_clear_close_on_exec(v_stdin , &si.hStdInput ) ||
       !dup2_and_clear_close_on_exec(v_stdout, &si.hStdOutput) ||
       !dup2_and_clear_close_on_exec(v_stderr, &si.hStdError )) {
-    win32_maperr(GetLastError());
+    caml_win32_maperr(GetLastError());
     close_std_handles(&si);
     uerror("DuplicateHandle", Nothing);
   }
 
-  if (!CreateProcess(String_val(v_prog),
-                     Bytes_val(v_cmdline),
-                     NULL,
-                     NULL,
-                     TRUE,
-                     0,
-                     Is_block(v_env) ? Bytes_val(Field(v_env, 0)) : NULL,
-                     Is_block(v_cwd) ? String_val(Field(v_cwd, 0)) : NULL,
-                     &si,
-                     &pi)) {
-    win32_maperr(GetLastError());
+  result =
+    CreateProcess(prog, cmdline, NULL, NULL, TRUE, CREATE_UNICODE_ENVIRONMENT,
+                  env, cwd, &si, &pi);
+
+  caml_stat_free(prog);
+  caml_stat_free(cmdline);
+  caml_stat_free(env);
+  caml_stat_free(cwd);
+
+  if (!result) {
+    caml_win32_maperr(GetLastError());
     close_std_handles(&si);
     uerror("CreateProcess", Nothing);
   }

--- a/src/spawn_stubs.c
+++ b/src/spawn_stubs.c
@@ -664,7 +664,7 @@ CAMLprim value spawn_windows(value v_env,
     v_env = Field(v_env, 0);
     mlsize_t len = caml_string_length(v_env);
     int size = caml_win32_multi_byte_to_wide_char(String_val(v_env), len, NULL, 0);
-    env = caml_stat_alloc((size + 1) * sizeof(WCHAR));
+    env = caml_stat_alloc(size * sizeof(WCHAR));
     caml_win32_multi_byte_to_wide_char(String_val(v_env), len, env, size);
   }
 


### PR DESCRIPTION
Subsumes #55. Fixes #57. Fixes https://github.com/ocaml/dune/issues/10180 which then fixes https://github.com/ocaml/opam/issues/5861.

Windows OCaml uses UTF-8 internally for environment variables. The `spawn_windows` stub was using the ANSI version of `CreateProcess` (`CreateProcessA`) which causes the environment to become corrupted if the environment contained any non-ASCII characters (i.e. any UTF-8 sequences).

Support for Windows 98 ended in July 2006, so I think we can risk using the Unicode version of `CreateProcess` 😉 The code mirrors that for `Unix.create_process`.