### PR TITLE
Fix stubs for non-glibc

### DIFF
--- a/src/spawn_stubs.c
+++ b/src/spawn_stubs.c
@@ -15,16 +15,14 @@
 #endif
 #endif
 
-/* for [caml_convert_signal_number] */
-#include <caml/signals.h>
-
-#undef CAML_INTERNALS
-
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/unixsupport.h>
 #include <caml/fail.h>
+
+/* for [caml_convert_signal_number]; must come after public caml headers */
+#include <caml/signals.h>
 
 #include <errno.h>
 


### PR DESCRIPTION
`caml/signals.h` is not public API; it does not include `caml/config.h` and so it will not include `signal.h` because it does not know about `POSIX_SIGNAL`. This issue is visible on musl as "unknown type `sigset_t`".
