### PR TITLE
Do not require C99 mode for older GCC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Support older GCC like 4.8.5 (#59)
+
 - Fix spawning processes on Windows when environment contains non-ascii
   characters (#58)
 

--- a/src/spawn_stubs.c
+++ b/src/spawn_stubs.c
@@ -499,8 +499,8 @@ CAMLprim value spawn_unix(value v_env,
         caml_failwith("Unknown sigprocmask action");
     }
 
-    for (value v_signals_list = Field(v_sigprocmask, 1);
-         v_signals_list != Val_emptylist;
+    value v_signals_list = Field(v_sigprocmask, 1);
+    for (; v_signals_list != Val_emptylist;
          v_signals_list = Field(v_signals_list, 1)) {
       int signal = caml_convert_signal_number(Long_val(Field(v_signals_list, 0)));
       switch (sigprocmask_command) {


### PR DESCRIPTION
This PR avoids the following error on an older GCC 4.8.5:

```
#=== ERROR while compiling dune.3.15.0 ========================================#
# context     2.2.0~alpha0~20221228 | linux/x86_64 |  | git+https://github.com/ocaml/opam-repository.git
# path        /work/.ci/o/2.1.1/.opam-switch/build/dune.3.15.0
# command     /work/.ci/o/2.1.1/bin/ocaml boot/bootstrap.ml -j 1
# exit-code   2
# env-file    /work/.ci/o/log/dune-11998-d28a2a.env
# output-file /work/.ci/o/log/dune-11998-d28a2a.out
### output ###
# ocamlc -output-complete-exe -w -24 -g -o .duneboot.exe -I boot unix.cma boot/libs.ml boot/duneboot.ml
# ./.duneboot.exe -j 1
# cd _boot && /work/.ci/o/2.1.1/bin/ocamlopt.opt -c -g -I +threads spawn_stubs.c
# vendor/spawn/src/spawn_stubs.c: In function 'init_spawn_info':
# vendor/spawn/src/spawn_stubs.c:526:5: error: 'for' loop initial declarations are only allowed in C99 mode
# vendor/spawn/src/spawn_stubs.c:526:5: note: use option -std=c99 or -std=gnu99 to compile your code
```

OP: https://github.com/ocaml/dune/issues/10423